### PR TITLE
CSTMRSCCSS-881

### DIFF
--- a/Akamai/akamai_datastream2_transform.json
+++ b/Akamai/akamai_datastream2_transform.json
@@ -1696,6 +1696,63 @@
           "script": null,
           "suppress": false
         }
+      },
+      {
+          "name": "contentProtectionInfo",
+          "datatype": {
+              "type": "string",
+              "index": true,
+              "source": null,
+              "format": null,
+              "resolution": "seconds",
+              "default": null,
+              "script": null,
+              "suppress": false
+          }
+      },
+      {
+          "name": "deliveryFormat",
+          "datatype": {
+              "type": "string",
+              "index": true,
+              "source": null,
+              "format": null,
+              "resolution": "seconds",
+              "default": null,
+              "script": null,
+              "suppress": false
+          }
+      },
+      {
+          "name": "deliveryType",
+          "datatype": {
+              "type": "string",
+              "index": true,
+              "source": null,
+              "format": null,
+              "resolution": "seconds",
+              "default": null,
+              "script": null,
+              "suppress": false
+          }
+      },
+      {
+          "name": "mediaEncryption",
+          "datatype": {
+              "type": "boolean",
+              "index": true,
+              "index_options": {
+                  "fulltext": false
+              },
+              "primary": false,
+              "source": null,
+              "ignore": false,
+              "format": null,
+              "resolution": "seconds",
+              "default": null,
+              "script": null,
+              "suppress": false
+          }
       }
     ],
     "compression": "none",


### PR DESCRIPTION
Adding contentProtectionInfo, deliveryFormat, deliveryType and mediaEncryption to default ds2 transform

1.     “contentProtectionInfo" > set as string, example value '=//epd@feature-override/v1/or/epd@geoguard/v1/dp/2'
2.     "deliveryFormat" > set as string, example values 'HDS', 'HLS', 'DASH'
3.     "deliveryType" > set as string, example values 'live', 'default'
4.     "mediaEncryption” > set as boolean, example values '0', '1'

All example values gathered from https://techdocs.akamai.com/datastream2/docs/data-set-parameters
 

