### PR TITLE
Changing datatype for paramsAkCp field from string to uint32

### DIFF
--- a/mPulse/mpulse_transform.json
+++ b/mPulse/mpulse_transform.json
@@ -7856,7 +7856,7 @@
                 "name": "paramsAkCp",
                 "datatype":
                 {
-                    "type": "string",
+                    "type": "uint32",
                     "index": true,
                     "index_options":
                     {


### PR DESCRIPTION
paramsAkCp seems to be the mPulse equivalent to the CP code field in the standard akamai.logs table and hence should be a uint32. 

https://techdocs.akamai.com/mpulse-boomerang/docs/whats-in-an-mpulse-beacon#akamai