### PR TITLE
CSTMRSCCSS-1833-2 - Update SIA transforms after data structure change

### DIFF
--- a/Akamai/akamai_uls_siae_aup.json
+++ b/Akamai/akamai_uls_siae_aup.json
@@ -1711,60 +1711,6 @@
         }
       },
       {
-        "name": "event",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "format": null,
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/event"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "query",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "format": null,
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/query"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
         "name": "hdx_source_latency",
         "datatype": {
           "type": "uint32",

--- a/Akamai/akamai_uls_siae_dns.json
+++ b/Akamai/akamai_uls_siae_dns.json
@@ -1627,60 +1627,6 @@
         }
       },
       {
-        "name": "event",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "format": null,
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/event"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "query",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "format": null,
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/query"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
         "name": "unknown",
         "datatype": {
           "type": "map",

--- a/Akamai/akamai_uls_siae_threat.json
+++ b/Akamai/akamai_uls_siae_threat.json
@@ -1668,60 +1668,6 @@
         }
       },
       {
-        "name": "event",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "format": null,
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/event"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
-        "name": "query",
-        "datatype": {
-          "type": "map",
-          "index": true,
-          "format": null,
-          "resolution": "seconds",
-          "default": null,
-          "script": null,
-          "elements": [
-            {
-              "type": "string",
-              "index": true
-            },
-            {
-              "type": "string",
-              "index": true
-            }
-          ],
-          "source": {
-            "from_json_pointers": [
-              "/query"
-            ]
-          },
-          "suppress": true
-        }
-      },
-      {
         "name": "hdx_source_latency",
         "datatype": {
           "type": "uint32",


### PR DESCRIPTION
These fields are not needed for calculations.
Due to the nested structure of the logs, creating these fields helped with debugging and not cluttering the "unknown" field too much.

Removed now as we observed intake-head errors due to a changed data format.