### PR TITLE
Removed resolution from referer field in the SIEM transform

### DIFF
--- a/Akamai/akamai_siem_transform.json
+++ b/Akamai/akamai_siem_transform.json
@@ -91,7 +91,6 @@
           "type": "string",
           "index": true,
           "format": null,
-          "resolution": "seconds",
           "default": null,
           "script": null,
           "source": {


### PR DESCRIPTION
Missed that one during the last cleanup, raised by CaC team:
https://hydrolix.slack.com/archives/C01H6VBK3A8/p1748602711521529?thread_ts=1747678286.283859&cid=C01H6VBK3A8