### PR TITLE
Do not index request and response headers map

### DIFF
--- a/Akamai/akamai_siem_transform.json
+++ b/Akamai/akamai_siem_transform.json
@@ -975,7 +975,7 @@
                 "name": "requestHeaders",
                 "datatype": {
                     "type": "map",
-                    "index": true,
+                    "index": false,
                     "format": null,
                     "resolution": null,
                     "default": null,
@@ -1000,7 +1000,7 @@
                 "name": "responseHeaders",
                 "datatype": {
                     "type": "map",
-                    "index": true,
+                    "index": false,
                     "format": null,
                     "resolution": null,
                     "default": null,


### PR DESCRIPTION
They are high cardinality and result in enormous column dictionaries